### PR TITLE
Accept terminal file argument

### DIFF
--- a/source/read-input.js
+++ b/source/read-input.js
@@ -1,5 +1,9 @@
 module.exports = function(stdin, opt, callback) {
-  stdin.pipe(require('concat-stream')(function(buffer) {
+  var source = (
+    opt.FILE ?
+      require('fs').createReadStream(opt.FILE) :
+      stdin )
+  source.pipe(require('concat-stream')(function(buffer) {
     var input = buffer.toString()
     var transform = (
       input.trim()[0] === '{' ?

--- a/source/usage.txt
+++ b/source/usage.txt
@@ -2,16 +2,16 @@ Compose, verify, and share form contracts
 
 Usage:
   commonform [--usage]
-  commonform critique
-  commonform definitions
-  commonform directions
-  commonform hash
-  commonform headings
-  commonform lint
-  commonform references
-  commonform render [options]
-  commonform share
-  commonform uses
+  commonform critique [FILE]
+  commonform definitions [FILE]
+  commonform directions [FILE]
+  commonform hash [FILE]
+  commonform headings [FILE]
+  commonform lint [FILE]
+  commonform references [FILE]
+  commonform render [options] [FILE]
+  commonform share [FILE]
+  commonform uses [FILE]
   commonform --help | -h
   commonform --version | -v
 

--- a/test/uses.test.js
+++ b/test/uses.test.js
@@ -18,3 +18,16 @@ test('uses', function(test) {
       outputs.status, 0,
       'uses < example.json exits with status 0')
     test.end() }) })
+
+test('uses FILE', function(test) {
+  var input = {
+    argv: [ 'uses', fixture('simple.json') ] }
+  invoke(cli, input, function(outputs) {
+    test.equal(
+      outputs.stdout,
+      [ 'Agreement', 'Party' ].join('\n') + '\n',
+      'uses example.json writes used terms to output')
+    test.equal(
+      outputs.status, 0,
+      'uses example.json exits with status 0')
+    test.end() }) })


### PR DESCRIPTION
@tbrooke: This enables file arguments for input, rather than piping standard input.

For example:

``` bash
commonform render --format docx some-contract.cform
```

File arguments should also work for other subcommands, too:

``` bash
commonform lint some-contract.cform
```
