### PR TITLE
Add usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Compose, verify, and share form contracts at the command line.
 
-Installation
-============
+# Installation
 
 At the command line, with [npm](https://npmjs.com) installed:
 
@@ -12,7 +11,6 @@ commonform --help
 
 `commonform-cli` is tested on the current Stable and Long Term Support (LTS) versions of [Node.js](https://nodejs.org). Please see the [Travis CI configuration file](./.travis.yml).
 
-Related Projects
-================
+# Related Projects
 
 For [Vim](https://github.com/commonform/vim-commonform) users there is also [vim-commonform](https://github.com/commonform/vim-commonform) with syntax highlighting and conveniences for Common Form markup.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,51 @@ commonform --help
 
 `commonform-cli` is tested on the current Stable and Long Term Support (LTS) versions of [Node.js](https://nodejs.org). Please see the [Travis CI configuration file](./.travis.yml).
 
+# Examples
+
+You may like to download a few sample form documents to start:
+
+```shellsession
+$ git clone https://github.com/commonform/commonform-samples samples
+$ cd samples
+```
+
+To format a form, say the Orrick Mutual NDA, for reading in the terminal:
+
+```shellsession
+$ commonform render Orrick-Mutual-NDA.commonform
+```
+
+To convert to OfficeOpenXML (.docx) for Microsoft Word:
+
+```shellsession
+$ commonform render --format docx Orrick-Mutual-NDA.commonform
+```
+
+And with a title:
+
+```shellsession
+$ commonform render --title "Mutual Nondisclosure Agrement" --format docx Orrick-Mutual-NDA.commonform
+```
+
+To check a form for technical errors:
+
+```shellsession
+$ commonform lint SAFE-MFN.commonform
+```
+
+And to view automated style critiques:
+
+```shellsession
+$ commonform critique IBM-Cloud-Services-Agreement.commonform
+```
+
+To see a list of additional subcommands and their options:
+
+```shellsession
+$ commonform --usage
+```
+
 # Related Projects
 
 For [Vim](https://github.com/commonform/vim-commonform) users there is also [vim-commonform](https://github.com/commonform/vim-commonform) with syntax highlighting and conveniences for Common Form markup.

--- a/source/read-input.js
+++ b/source/read-input.js
@@ -1,5 +1,9 @@
 module.exports = function(stdin, opt, callback) {
-  stdin.pipe(require('concat-stream')(function(buffer) {
+  var source = (
+    opt.FILE ?
+      require('fs').createReadStream(opt.FILE) :
+      stdin )
+  source.pipe(require('concat-stream')(function(buffer) {
     var input = buffer.toString()
     var transform = (
       input.trim()[0] === '{' ?

--- a/source/usage.txt
+++ b/source/usage.txt
@@ -2,16 +2,16 @@ Compose, verify, and share form contracts
 
 Usage:
   commonform [--usage]
-  commonform critique
-  commonform definitions
-  commonform directions
-  commonform hash
-  commonform headings
-  commonform lint
-  commonform references
-  commonform render [options]
-  commonform share
-  commonform uses
+  commonform critique [FILE]
+  commonform definitions [FILE]
+  commonform directions [FILE]
+  commonform hash [FILE]
+  commonform headings [FILE]
+  commonform lint [FILE]
+  commonform references [FILE]
+  commonform render [options] [FILE]
+  commonform share [FILE]
+  commonform uses [FILE]
   commonform --help | -h
   commonform --version | -v
 

--- a/test/uses.test.js
+++ b/test/uses.test.js
@@ -18,3 +18,16 @@ test('uses', function(test) {
       outputs.status, 0,
       'uses < example.json exits with status 0')
     test.end() }) })
+
+test('uses FILE', function(test) {
+  var input = {
+    argv: [ 'uses', fixture('simple.json') ] }
+  invoke(cli, input, function(outputs) {
+    test.equal(
+      outputs.stdout,
+      [ 'Agreement', 'Party' ].join('\n') + '\n',
+      'uses example.json writes used terms to output')
+    test.equal(
+      outputs.status, 0,
+      'uses example.json exits with status 0')
+    test.end() }) })


### PR DESCRIPTION
@tbrooke: This PR adds a few usage examples to README, just to get folks started. All of the examples use the new file-argument, since I agree that folks are probably more accustomed to that style.
