### PR TITLE
Add `commonform share --open`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docopt": "^0.6.2",
     "english-list": "^1.0.0-prerelease-1",
     "ooxml-signature-pages": "^0.5.0",
+    "opener": "^1.4.1",
     "outline-numbering": "~0.2.0",
     "resolutions-schedules-exhibits-numbering": "~0.1.0"
   },

--- a/source/route.js
+++ b/source/route.js
@@ -92,10 +92,11 @@ module.exports = function(stdin, stdout, stderr, env, opt) {
           path: '/forms' }
         https.request(request, function(response) {
           if (response.statusCode === 200) {
-            stdout.write(
-              'https://api.commonform.org' +
-              response.headers.location +
-              '\n')
+            var location = response.headers.location
+            stdout.write('https://api.commonform.org' + location + '\n')
+            /* istanbul ignore if */
+            if (opt['--open']) {
+              require('opener')('https://commonform.org' + location) }
             callback(0) }
           else {
             stderr.write(

--- a/source/usage.txt
+++ b/source/usage.txt
@@ -10,7 +10,7 @@ Usage:
   commonform lint [FILE]
   commonform references [FILE]
   commonform render [options] [FILE]
-  commonform share [FILE]
+  commonform share [FILE] [--open]
   commonform uses [FILE]
   commonform --help | -h
   commonform --version | -v
@@ -21,4 +21,5 @@ Options:
   -b BLANKS, --blanks BLANKS    File containing fill-in-the-blank values
   -f FORMAT, --format FORMAT    Output format [default: terminal]
   -n STYLE, --number STYLE      Numbering style [default: decimal]
+  -o, --open                    Open shared form in your web browser
   -s PAGES, --signatures PAGES  Signature page data


### PR DESCRIPTION
This PR adds an `--open` flag to `commonform share` that opens the shared form up on commonform.org.

Inspired: commonform/help#1

cc @anseljh @tbrooke
