### PR TITLE
Remove "FORCE_COLOR=true" from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   "preferGlobal": true,
   "repository": "commonform/commonform-cli",
   "scripts": {
-    "coverage": "FORCE_COLOR=true istanbul check-coverage coverage/coverage.json",
+    "coverage": "istanbul check-coverage coverage/coverage.json",
     "precommit": "npm run coverage",
     "precoverage": "istanbul cover -- tape test/*.test.js",
-    "test": "FORCE_COLOR=true tape test/*.test.js"
+    "test": "tape test/*.test.js"
   }
 }


### PR DESCRIPTION
Not sure why, but this makes my systems barf. Maybe there's a more cross-platform way to do this?
