### PR TITLE
revive support for `blanks` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ $ commonform --usage
 # Related Projects
 
 For [Vim](https://github.com/commonform/vim-commonform) users there is also [vim-commonform](https://github.com/commonform/vim-commonform) with syntax highlighting and conveniences for Common Form markup.
+
+# Schema Validation
+
+Does your context JSON fit the commonform? Are there unfilled blanks or type mismatches? You could define a JSON schema based on the form and validate the JSON against the schema. This functionality isn't part of the commonform-cli, and can be done separately by any number of schema validators. See the `cftemplate` repository for an example, in `examples/SAFE.schema.json`.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commonform-cli",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commonform-cli",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commonform-cli",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commonform-cli",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commonform-cli",
   "description": "compose, verify, and share form contracts at the command line",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bin": {
     "commonform": "./bin/commonform"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commonform-cli",
   "description": "compose, verify, and share form contracts at the command line",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bin": {
     "commonform": "./bin/commonform"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commonform-cli",
   "description": "compose, verify, and share form contracts at the command line",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bin": {
     "commonform": "./bin/commonform"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commonform-cli",
   "description": "compose, verify, and share form contracts at the command line",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bin": {
     "commonform": "./bin/commonform"

--- a/source/route.js
+++ b/source/route.js
@@ -112,6 +112,19 @@ module.exports = function (stdin, stdout, stderr, env, opt) {
         callback(0)
       }))
     }
+  } else if (opt.blanks) {
+    return function (callback) {
+      require('./read-input')(stdin, opt, function (error, input) {
+        if (error) return callback(error)
+        input.directions
+          .map(function(d){return d.identifier})
+          .sort()
+          .forEach(function (element) {
+            stdout.write(element + '\n')
+          })
+        callback(0)
+      })
+    }
   } else if (opt.publish) {
     return function (callback) {
       require('./read-input')(stdin, opt, function (error, input) {

--- a/source/transform-for-format.js
+++ b/source/transform-for-format.js
@@ -42,7 +42,12 @@ module.exports = function (format, opt) {
     return function (argument) {
       var blanks = []
       var blanksPath = opt['--blanks']
-      if (blanksPath) {
+      // usually we read the blanks JSON from disk
+      // but sometimes the caller hands it to us directly
+      if (opt.blanksObj) {
+        blanks = opt.blanksObj
+      }
+      else if (blanksPath) {
         blanks = JSON.parse(require('fs').readFileSync(blanksPath))
       }
       var sigpages

--- a/source/transform-for-format.js
+++ b/source/transform-for-format.js
@@ -42,12 +42,7 @@ module.exports = function (format, opt) {
     return function (argument) {
       var blanks = []
       var blanksPath = opt['--blanks']
-      // usually we read the blanks JSON from disk
-      // but sometimes the caller hands it to us directly
-      if (opt.blanksObj) {
-        blanks = opt.blanksObj
-      }
-      else if (blanksPath) {
+      if (blanksPath) {
         blanks = JSON.parse(require('fs').readFileSync(blanksPath))
       }
       var sigpages

--- a/source/usage.txt
+++ b/source/usage.txt
@@ -2,16 +2,17 @@ Compose, verify, and share form contracts
 
 Usage:
   commonform [--usage]
-  commonform critique [FILE]
-  commonform definitions [FILE]
-  commonform directions [FILE]
-  commonform hash [FILE]
-  commonform headings [FILE]
-  commonform lint [FILE]
-  commonform publish PROJECT EDITION [FILE]
-  commonform references [FILE]
+  commonform headings     [FILE]
+  commonform references   [FILE]
+  commonform definitions  [FILE]
+  commonform uses         [FILE]
+  commonform blanks       [FILE]
+  commonform lint         [FILE]
+  commonform critique     [FILE]
+  commonform hash         [FILE]
   commonform render [options] [FILE]
-  commonform uses [FILE]
+  commonform publish PROJECT EDITION [FILE]
+  commonform directions   [ < FILE ]
   commonform --help | -h
   commonform --version | -v
 
@@ -20,8 +21,8 @@ Options:
   -t TITLE, --title TITLE       Form title to be rendered
   -e EDITION, --edition EDITION Form edition to be rendered
   -H, --hash                    Render form hash
-  -b BLANKS, --blanks BLANKS    File containing fill-in-the-blank values
-  -m , --mark-filled            Mark filled-in blanks
+  -b BLANKS, --blanks BLANKS    JSON file containing fill-in-the-blank values
+  -m, --mark-filled             Mark filled-in blanks
   -p TEXT, --blank-text TEXT    Placeholder text for unfilled blanks
   -f FORMAT, --format FORMAT    Output format [default: terminal]
   -n STYLE, --number STYLE      Numbering style [default: decimal]
@@ -29,3 +30,16 @@ Options:
   -i, --indent-margins          Indent margins, commonwealth style
   -l, --left-align-title        Align title flush to left margin
   -L, --ordered-lists           Render order lists in HTML output
+
+Commands:
+  headings       List of \ Headings \.
+  references     List of references to {Headings}.
+  definitions    List of ""Defined Terms"".
+  uses           List of uses of <Defined Terms>.
+  blanks         List of [Blanks] to be filled by a -b option JSON file.
+  lint           Warnings and errors.
+  critique       How might one improve the language? Ken Adams in a box.
+  hash           Cryptographic hash of the form.
+  render         Render the commonform to an output format.
+  publish        Publish the project.
+  directions     Internal: Details of blanks. NOTE! Expects STDIN, not a file.

--- a/test/blanks.test.js
+++ b/test/blanks.test.js
@@ -1,0 +1,26 @@
+var fs = require('fs')
+var test = require('tape')
+var fixture = require('./helpers/fixture')
+var invoke = require('./helpers/invoke')
+var cli = require('..')
+
+test('blanks', function (test) {
+  var input = {
+    argv: ['blanks'],
+    stdin: function () {
+      return fs.createReadStream(fixture('simple-with-directions.commonform'))
+    }
+  }
+  invoke(cli, input, function (outputs) {
+    test.equal(
+      outputs.stdout,
+      'Company\'s Form of Organization\nCompany\'s Name\n',
+      'blank simple-with-directions.commonform writes expected blanks to output'
+    )
+    test.equal(
+      outputs.status, 0,
+      'headings < example.json exits with status 0'
+    )
+    test.end()
+  })
+})

--- a/test/directions.test.js
+++ b/test/directions.test.js
@@ -24,7 +24,7 @@ test('directions < simple-with-directions.commonform', function (test) {
           path: ['content', 11]
         }
       ],
-      'directions reports an archaic phrase'
+      'directions shows expected blank identifiers'
     )
     test.equal(
       outputs.status, 0,


### PR DESCRIPTION
there is some history between `blanks` and `directions` that I wish I understood better. But this pull request leaves `directions` alone and only revives `blanks`.

also rewrote the usage.txt docopt file to document each sub-command.

brief suggestion that the user might want to do some schema validation